### PR TITLE
Fix update all

### DIFF
--- a/aur-update
+++ b/aur-update
@@ -215,56 +215,12 @@ print_starting_sync ()
 	printf "${WHITE}Syncing aur-pkglist with current directories...${NC}\n"
 }
 
-TEMP=$(getopt -o 'hso:' --long 'help,sync,only:' -n 'AUR-Update Error' -- "$@")
-
-if [ $? -ne 0 ]; then
-	echo 'Terminating...' >&2
-	exit 1
-fi
-
-eval set -- "$TEMP"
-unset TEMP
-
-while true; do
-	case "$1" in
-		'-h'|'--help' )
-			echo 'Usage:'
-			echo 'aur-update [-o|--only] package-name'
-			echo '    Update only package-name'
-			echo 'aur-update [-s|--sync]'
-			echo '    Update aur-pkglist with latest packages in aurpath directory'
-			echo 'aur-update [-h|--help]'
-			echo '    Print this message and exit'
-			exit 0
-		;;
-		'-o'|'--only' )
-			pkg_name=$OPTARG
-		;;
-		'-s'|'--sync' )
-			print_starting_sync
-			init_pkg_list
-			for d in ./*/; do
-				loop_get_pkg_name_and_len
-				add_pkg_name_to_pkglist
-			done
-			sync_pkglist
-			print_end_sync
-			exit 0
-		;;
-		\? )
-			echo "Invalid option: $OPTARG" 1>&2
-		;;
-		: )
-			echo "Invalid option: $OPTARG requires an argument" 1>&2
-		;;
-	esac
-done
-
 # cd into AUR repository directory
 cd "$aurpath"
 
 # If no package has been specified by '-o' flag ($pkg_name is unset)
-if [ -z ${pkg_name+x} ]; then
+if [ -z $1 ]; then
+	echo HI
 	init_pkg_list
 	print_starting_updates
 	for d in ./*/; do
@@ -278,16 +234,69 @@ if [ -z ${pkg_name+x} ]; then
 
 	print_end_message
 	exit 0
-# elif $pkg_name is a directory in $aurpath directory
-elif [ -d $pkg_name ]; then
-	print_starting_only
-	cd $pkg_name
-	# Set pkg_name_len outside of loop_get_pkg_name_and_len
-	pkg_name_len=${#pkg_name}
-	update_aur_pkg
-	print_end_message
-	exit 0
+
 else
-	echo "ERROR - Aborting!"
-	exit 1
+	TEMP=$(getopt -o 'hso:' --long 'help,sync,only:' -n 'AUR-Update Error' -- "$@")
+
+	if [ $? -ne 0 ]; then
+		echo 'Terminating...' >&2
+		exit 1
+	fi
+
+	eval set -- "$TEMP"
+	unset TEMP
+
+	while true; do
+		case "$1" in
+			'-h'|'--help' )
+				echo 'Usage:'
+				echo 'aur-update [-o|--only] package-name'
+				echo '    Update only package-name'
+				echo 'aur-update [-s|--sync]'
+				echo '    Update aur-pkglist with latest packages in aurpath directory'
+				echo 'aur-update [-h|--help]'
+				echo '    Print this message and exit'
+				exit 0
+			;;
+			'-o'|'--only' )
+				pkg_name=$OPTARG
+				print_starting_only
+				cd $pkg_name
+				# Set pkg_name_len outside of loop_get_pkg_name_and_len
+				pkg_name_len=${#pkg_name}
+				update_aur_pkg
+				print_end_message
+				exit 0
+			;;
+			'-s'|'--sync' )
+				print_starting_sync
+				init_pkg_list
+				for d in ./*/; do
+					loop_get_pkg_name_and_len
+					add_pkg_name_to_pkglist
+				done
+				sync_pkglist
+				print_end_sync
+				exit 0
+			;;
+			\? )
+				echo "Invalid option: $OPTARG" 1>&2
+			;;
+			: )
+				echo "Invalid option: $OPTARG requires an argument" 1>&2
+			;;
+		esac
+	done
 fi
+
+
+
+
+
+# # elif $pkg_name is a directory in $aurpath directory
+# elif [ -d $pkg_name ]; then
+	
+# else
+# 	echo "ERROR - Aborting!"
+# 	exit 1
+# fi

--- a/aur-update
+++ b/aur-update
@@ -220,7 +220,6 @@ cd "$aurpath"
 
 # If no package has been specified by '-o' flag ($pkg_name is unset)
 if [ -z $1 ]; then
-	echo HI
 	init_pkg_list
 	print_starting_updates
 	for d in ./*/; do
@@ -260,6 +259,8 @@ else
 			;;
 			'-o'|'--only' )
 				pkg_name=$OPTARG
+				echo $OPTARG
+				echo $pkg_name
 				print_starting_only
 				cd $pkg_name
 				# Set pkg_name_len outside of loop_get_pkg_name_and_len

--- a/aur-update
+++ b/aur-update
@@ -233,21 +233,22 @@ if [ -z $1 ]; then
 
 	print_end_message
 	exit 0
-
 else
-	TEMP=$(getopt -o 'hso:' --long 'help,sync,only:' -n 'AUR-Update Error' -- "$@")
-
-	if [ $? -ne 0 ]; then
-		echo 'Terminating...' >&2
-		exit 1
-	fi
-
-	eval set -- "$TEMP"
-	unset TEMP
-
-	while true; do
-		case "$1" in
-			'-h'|'--help' )
+	# while getopts c:d: OPT; do
+	# 	case "$OPT" in
+	# 	d)
+	# 		DIR="$OPTARG" ;;
+	# 	c)
+	# 		COMMAND="$OPTARG" ;;
+	# 	[?])
+	# 		# got invalid option
+	# 		echo "Usage: $0 [-d directory] [-c command]" >&2
+	# 		exit 1 ;;
+	# 	esac
+	# done
+	while getopts hso: OPT; do
+		case "$OPT" in
+			h )
 				echo 'Usage:'
 				echo 'aur-update [-o|--only] package-name'
 				echo '    Update only package-name'
@@ -257,10 +258,13 @@ else
 				echo '    Print this message and exit'
 				exit 0
 			;;
-			'-o'|'--only' )
+			o )
 				pkg_name=$OPTARG
+				echo HIT ONLY
 				echo $OPTARG
+				echo SET
 				echo $pkg_name
+				echo DONE SET
 				print_starting_only
 				cd $pkg_name
 				# Set pkg_name_len outside of loop_get_pkg_name_and_len
@@ -269,7 +273,7 @@ else
 				print_end_message
 				exit 0
 			;;
-			'-s'|'--sync' )
+			s )
 				print_starting_sync
 				init_pkg_list
 				for d in ./*/; do


### PR DESCRIPTION
- Remove long options
- Fix update all
- `aur-pkglist` and `aur-pkglist.old` continue to break and currently require root