### PR TITLE
Resolve -s (sync) flag issue

### DIFF
--- a/aur-update
+++ b/aur-update
@@ -197,9 +197,9 @@ sync_pkglist ()
 	# Make package list and old package list files if they do not exist
 	# Convert package list to old package list
 	# Remake package list
-	touch ${aurpath}/aur-pkglist ${aurpath}/aur-pkglist.old
-	mv ${aurpath}/aur-pkglist ${aurpath}/aur-pkglist.old
-	touch ${aurpath}/aur-pkglist
+	touch aur-pkglist aur-pkglist.old
+	mv aur-pkglist aur-pkglist.old
+	touch aur-pkglist
 
 	# Add package list to new package list file
 	echo $pkg_list >> aur-pkglist


### PR DESCRIPTION
We were already in the `${aurpath}` directory; no need to specify it in the `touch`/`mv`/`touch` sequence.